### PR TITLE
recursive mkdirSync

### DIFF
--- a/scripts/install/kernel_spec.js
+++ b/scripts/install/kernel_spec.js
@@ -31,7 +31,7 @@ class KernelSpec {
         const { kernelDir, jsonPath, imgDir } = this._getIntsallPaths();
 
         if (!fs.existsSync(kernelDir)) {
-            fs.mkdirSync(kernelDir);
+            fs.mkdirSync(kernelDir, { recursive: true });
         }
 
         const kernelSpec = JSON.stringify({ argv, display_name, language });


### PR DESCRIPTION
Makes mkdirSync inside the install script recursive as documented [here](https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback).
closes https://github.com/3Nigma/nelu-kernelu/issues/1