### PR TITLE
on windows,get path from process.env.APPDATA

### DIFF
--- a/scripts/install/get_install_dir.js
+++ b/scripts/install/get_install_dir.js
@@ -13,7 +13,7 @@ const getInstallDir = () => {
 
     switch (osType) {
         case "Windows_NT":
-            return "%APPDATA%\\jupyter\\kernels";
+            return path.join(process.env.APPDATA,'jupyter/kernels');
         case "Darwin":
             return path.join(homeDir, "Library/Jupyter/kernels");
         case "Linux":


### PR DESCRIPTION
 get path from `process.env.APPDATA`,not `%APPDATA%`
> [https://stackoverflow.com/a/26227660](https://stackoverflow.com/a/26227660)

if use %APPDATA% in path, it will create a folder called "%APPDATA%" in current working dir